### PR TITLE
Enable Log Prefix for Console Logger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.520</version>
+        <version>1.557</version>
     </parent>
 
     <artifactId>audit-trail</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.2</version>
+        <version>1.557</version>
     </parent>
 
     <artifactId>audit-trail</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.557</version>
+        <version>2.2</version>
     </parent>
 
     <artifactId>audit-trail</artifactId>

--- a/src/main/java/hudson/plugins/audit_trail/ConsoleAuditLogger.java
+++ b/src/main/java/hudson/plugins/audit_trail/ConsoleAuditLogger.java
@@ -27,8 +27,7 @@ public class ConsoleAuditLogger extends AuditLogger {
             throw new NullPointerException("output can not be null");
         if(dateFormat == null)
             throw new NullPointerException("dateFormat can not be null");
-        System.out.println("PREFIX");
-        System.out.println(prefixName);
+        
         if (prefixName == null || prefixName.equals("")) {
             prefix = " - ";
         } else {

--- a/src/main/java/hudson/plugins/audit_trail/ConsoleAuditLogger.java
+++ b/src/main/java/hudson/plugins/audit_trail/ConsoleAuditLogger.java
@@ -19,15 +19,22 @@ public class ConsoleAuditLogger extends AuditLogger {
     private final PrintStream out;
     private final String dateFormat;
     private final SimpleDateFormat sdf;
-
+    private final String prefix;
 
     @DataBoundConstructor
-    public ConsoleAuditLogger(Output output, String dateFormat) {
+    public ConsoleAuditLogger(Output output, String dateFormat, String prefixName) {
         if (output == null)
             throw new NullPointerException("output can not be null");
         if(dateFormat == null)
             throw new NullPointerException("dateFormat can not be null");
-
+        System.out.println("PREFIX");
+        System.out.println(prefixName);
+        if (prefixName == null || prefixName.equals("")) {
+            prefix = " - ";
+        } else {
+            prefix = String.format(" - %s - ", prefixName);
+        }
+                
         this.output = output;
         switch (output) {
             case STD_ERR:
@@ -46,7 +53,7 @@ public class ConsoleAuditLogger extends AuditLogger {
     @Override
     public void log(String event) {
         synchronized (sdf) {
-            this.out.println(sdf.format(new Date()) + " - " + event);
+            this.out.println(sdf.format(new Date()) + this.prefix + event);
         }
     }
 
@@ -62,6 +69,8 @@ public class ConsoleAuditLogger extends AuditLogger {
     public String getDateFormat() {
         return this.dateFormat;
     }
+    
+    public String getPrefix() {return this.prefix;}
 
     @Extension
     public static class DescriptorImpl extends Descriptor<AuditLogger> {
@@ -90,7 +99,8 @@ public class ConsoleAuditLogger extends AuditLogger {
 
         if (!dateFormat.equals(that.dateFormat)) return false;
         if (output != that.output) return false;
-
+        if (!prefix.equals(that.prefix)) return false;
+        
         return true;
     }
 
@@ -98,6 +108,7 @@ public class ConsoleAuditLogger extends AuditLogger {
     public int hashCode() {
         int result = output.hashCode();
         result = 31 * result + dateFormat.hashCode();
+        result = 31 * result + prefix.hashCode();
         return result;
     }
 }

--- a/src/main/java/hudson/plugins/audit_trail/ConsoleAuditLogger.java
+++ b/src/main/java/hudson/plugins/audit_trail/ConsoleAuditLogger.java
@@ -19,21 +19,17 @@ public class ConsoleAuditLogger extends AuditLogger {
     private final PrintStream out;
     private final String dateFormat;
     private final SimpleDateFormat sdf;
-    private final String prefix;
-
+    private final String logPrefix;
+    private String logPrefixPadded;
+    
     @DataBoundConstructor
-    public ConsoleAuditLogger(Output output, String dateFormat, String prefixName) {
+    public ConsoleAuditLogger(Output output, String dateFormat, String logPrefix) {
         if (output == null)
             throw new NullPointerException("output can not be null");
         if(dateFormat == null)
             throw new NullPointerException("dateFormat can not be null");
         
-        if (prefixName == null || prefixName.equals("")) {
-            prefix = " - ";
-        } else {
-            prefix = String.format(" - %s - ", prefixName);
-        }
-                
+        this.logPrefix = logPrefix;
         this.output = output;
         switch (output) {
             case STD_ERR:
@@ -52,7 +48,7 @@ public class ConsoleAuditLogger extends AuditLogger {
     @Override
     public void log(String event) {
         synchronized (sdf) {
-            this.out.println(sdf.format(new Date()) + this.prefix + event);
+            this.out.println(sdf.format(new Date()) + this.getLogPrefixPadded() + event);
         }
     }
 
@@ -69,8 +65,20 @@ public class ConsoleAuditLogger extends AuditLogger {
         return this.dateFormat;
     }
     
-    public String getPrefix() {return this.prefix;}
-
+    public String getLogPrefix() {return this.logPrefix;}
+    
+    private Boolean hasLogPrefix() {return this.logPrefix != null && !this.logPrefix.equals("");}
+    
+    private String getLogPrefixPadded() {
+        if (hasLogPrefix()) {
+            if (logPrefixPadded == null)
+                logPrefixPadded = String.format(" - %s - ", getLogPrefix());
+            return logPrefixPadded;
+        }
+        
+        return " - ";
+    }
+    
     @Extension
     public static class DescriptorImpl extends Descriptor<AuditLogger> {
 
@@ -98,7 +106,7 @@ public class ConsoleAuditLogger extends AuditLogger {
 
         if (!dateFormat.equals(that.dateFormat)) return false;
         if (output != that.output) return false;
-        if (!prefix.equals(that.prefix)) return false;
+        if (!logPrefix.equals(that.logPrefix)) return false;
         
         return true;
     }
@@ -107,7 +115,7 @@ public class ConsoleAuditLogger extends AuditLogger {
     public int hashCode() {
         int result = output.hashCode();
         result = 31 * result + dateFormat.hashCode();
-        result = 31 * result + prefix.hashCode();
+        result = 31 * result + logPrefix.hashCode();
         return result;
     }
 }

--- a/src/main/resources/hudson/plugins/audit_trail/ConsoleAuditLogger/config.jelly
+++ b/src/main/resources/hudson/plugins/audit_trail/ConsoleAuditLogger/config.jelly
@@ -7,6 +7,9 @@
         <f:entry title="${%Date Format}" field="dateFormat">
             <f:textbox default="yyyy/MM/dd MM:ss:SSS"/>
         </f:entry>
+        <f:entry title="${%Log Prefix}" field="prefixName">
+            <f:textbox default=""/>
+        </f:entry>
     </f:advanced>
 
 </j:jelly>

--- a/src/main/resources/hudson/plugins/audit_trail/ConsoleAuditLogger/config.jelly
+++ b/src/main/resources/hudson/plugins/audit_trail/ConsoleAuditLogger/config.jelly
@@ -7,8 +7,8 @@
         <f:entry title="${%Date Format}" field="dateFormat">
             <f:textbox default="yyyy/MM/dd MM:ss:SSS"/>
         </f:entry>
-        <f:entry title="${%Log Prefix}" field="prefixName">
-            <f:textbox default=""/>
+        <f:entry title="${%Log Prefix}" field="logPrefix">
+            <f:textbox/>
         </f:entry>
     </f:advanced>
 

--- a/src/main/resources/hudson/plugins/audit_trail/ConsoleAuditLogger/help-prefixName.html
+++ b/src/main/resources/hudson/plugins/audit_trail/ConsoleAuditLogger/help-prefixName.html
@@ -1,0 +1,10 @@
+<br>
+    You may specify a prefix to include in each audit log line to enable easy filtering of audit log messages for the
+    standard out logger.
+    <br/></br/>
+    Example:  Log Prefix = "AUDIT"
+    <br/></br/>
+    <pre>
+    2017/07/18 07:46:418 - AUDIT - [audit message]
+    </pre>
+</div>


### PR DESCRIPTION
I'm currently using the console logger while running Jenkins in a docker container. All of my log output goes to **STDOUT** which is pushed to a log database like AWS CloudWatch Logs or Splunk. I would like the ability to distinguish between audit logs and regular Jenkins logs since both log to standard out.

By including an additional field called `Log Prefix` in the advanced section of the `Console Logger`, the user has the ability to optionally provide a prefix which would be included in all audit log messages.

**For example:**
Log Prefix = AUDIT

```
2017/07/18 07:46:418 - AUDIT - [audit message]
```
The default behaviour is the same as before but now you can optionally include the prefix.

Please let me know if you'd like me to make additional changes.

Thanks