### PR TITLE
[JENKINS-51331] - Update ConsoleAuditLogger to store configuration correctly

### DIFF
--- a/src/main/java/hudson/plugins/audit_trail/ConsoleAuditLogger.java
+++ b/src/main/java/hudson/plugins/audit_trail/ConsoleAuditLogger.java
@@ -16,9 +16,9 @@ public class ConsoleAuditLogger extends AuditLogger {
     public enum Output {STD_OUT, STD_ERR}
 
     private final Output output;
-    private final PrintStream out;
+    private transient PrintStream out;
     private final String dateFormat;
-    private final SimpleDateFormat sdf;
+    private transient SimpleDateFormat sdf;
 
 
     @DataBoundConstructor


### PR DESCRIPTION
This fixes the same problem as the old pull request with the same name from 2014. That change now crashes with a NullPointerException.
The audit-trail-plugin breaks on the latest Jenkins LTS (aka. 2.107.1) because the audit-trail.xml config file contains eg. a dump of the buffer used to write the log messages. Changing the PrintStream and the SimpleDateFormat to transient prevents them from being saved in the config file.