### PR TITLE
Fixes default date format to show time

### DIFF
--- a/src/main/resources/hudson/plugins/audit_trail/ConsoleAuditLogger/config.jelly
+++ b/src/main/resources/hudson/plugins/audit_trail/ConsoleAuditLogger/config.jelly
@@ -6,7 +6,7 @@
     </f:entry>
     <f:advanced>
         <f:entry title="${%Date Format}" field="dateFormat">
-            <f:textbox default="yyyy/MM/dd MM:ss:SSS"/>
+            <f:textbox default="yyyy-MM-dd HH:mm:ss:SSS"/>
         </f:entry>
         <f:entry title="${%Log Prefix}" field="logPrefix">
             <f:textbox/>


### PR DESCRIPTION
The default date format for console logging previously displayed months twice instead of showing minutes and did not display hours. This PR also adjusts the date format to be more in line with ISO 8601.