### PR TITLE
Add explicit license to pom and root of project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright 2019-2020 Pierre Beitz 
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,12 @@
         <tag>HEAD</tag>
     </scm>
 
+    <licenses>
+        <license>
+	    <name>MIT License</name>
+	</license>
+    </licenses>
+
     <developers>
         <developer>
             <id>pierrebtz</id>


### PR DESCRIPTION
This adds an explicit license file at the root of the project as well as the pom.xml. The license added is the same one I found in the source of the actual plugin.

Note that I have only added Pierre’s copyright notice since Pierre was the first person I saw in the contributors list though I’m sure there’s plenty others given this plugin has history. I figured the respective owners could add their own notice.