### PR TITLE
[JENKINS-63928] Prevent form name conflict

### DIFF
--- a/src/main/resources/hudson/plugins/audit_trail/BypassablePatternMonitor/message.groovy
+++ b/src/main/resources/hudson/plugins/audit_trail/BypassablePatternMonitor/message.groovy
@@ -12,7 +12,7 @@ dl {
         form(method: 'post', name: 'default', action: "${rootURL}/${monitor.url}/applyDefault") {
             input(name: 'default', type: 'submit', value: 'Apply default pattern', class: 'submit-button primary')
         }
-        form(method: 'get', name: 'config', action: "${rootURL}/${monitor.url}/redirectToConfig") {
+        form(method: 'get', name: 'redirect-to-config', action: "${rootURL}/${monitor.url}/redirectToConfig") {
             input(name: 'config', type: 'submit', value: 'Go to configuration', class: 'submit-button primary')
         }
         raw('<b>Found bypassable Audit Trail logging patterns:</b>')


### PR DESCRIPTION
See [JENKINS-63928](https://issues.jenkins.io/browse/JENKINS-63928)

Due to [this brittle code](https://github.com/jenkinsci/workflow-cps-plugin/blob/0e4c25f8d7b84470aa523491e29933db3b3df588/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly#L81), the snippet generator from pipeline was broken after the recent security release. The main form on the page of the snippet also has the name "config" and thus, `document.forms.config` only returns the first one (the monitor).

There is no need to use a form for a GET like this, it should be a link to let users ctrl/cmd-clicking it (to open in new tab), but it will be let to the maintainer as it's not related to the bug.

@PierreBtz @Dohbedoh @timja 