### PR TITLE
[JENKINS-65868] Added remote IP in log entry for Audit Trail logs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -59,6 +59,16 @@ Send audit logs to an Elastic Search server
 
 image:docs/images/jenkins-audit-trail-elastic-search-logger.png[image,width=400]
 
+
+=== About the client IP-address appearing in the logs
+====
+The plugin uses a method that cannot guarantee that the actual IP of the client is captured.
+https://javaee.github.io/javaee-spec/javadocs/javax/servlet/ServletRequest.html#getRemoteAddr--[More details]
+Be aware of this limitation, especially if your instance is configured behind a reverse proxy.
+For getting client IP-address correctly it's required to set HTTP-header *X-Forwarded-For* on the reverse proxy side.
+Also follow these https://www.jenkins.io/doc/book/system-administration/reverse-proxy-configuration-troubleshooting/--[recommendations] in order to get round this limitation.
+====
+
 == Changelog
 ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 

--- a/src/main/java/hudson/plugins/audit_trail/AuditTrailFilter.java
+++ b/src/main/java/hudson/plugins/audit_trail/AuditTrailFilter.java
@@ -85,7 +85,8 @@ public class AuditTrailFilter implements Filter {
         String uri = getPathInfo(req);
         if (uriPattern != null && uriPattern.matcher(uri).matches()) {
             User user = User.current();
-            String username = user != null ? user.getId() : req.getRemoteAddr();
+            String username = user != null ? user.getId() : "NA";
+            String remoteIP = req.getRemoteAddr();
             String extra = "";
             // For queue items, show what task is in the queue:
             if (uri.startsWith("/queue/item/")) {
@@ -102,9 +103,9 @@ public class AuditTrailFilter implements Filter {
             }
 
             if (LOGGER.isLoggable(Level.FINE))
-                LOGGER.log(Level.FINE, "Audit request {0} by user {1}", new Object[]{uri, username});
+                LOGGER.log(Level.FINE, "Audit request {0} by user {1} from {2}", new Object[]{uri, username, remoteIP});
 
-            onRequest(uri, extra, username);
+            onRequest(uri, extra, username, remoteIP);
         } else {
             LOGGER.log(Level.FINEST, "Skip audit for request {0}", uri);
         }
@@ -142,10 +143,10 @@ public class AuditTrailFilter implements Filter {
         PluginServletFilter.addFilter(injector.getInstance(AuditTrailFilter.class));
     }
 
-    private void onRequest(String uri, String extra, String username) {
+    private void onRequest(String uri, String extra, String username, String remoteIP) {
         if (configuration != null) {
             for (AuditLogger logger : configuration.getLoggers()) {
-                logger.log(uri + extra + " by " + username);
+                logger.log(uri + extra + " by " + username + " from " + remoteIP);
             }
         }
     }

--- a/src/test/java/hudson/plugins/audit_trail/AuditTrailFilterTest.java
+++ b/src/test/java/hudson/plugins/audit_trail/AuditTrailFilterTest.java
@@ -51,7 +51,7 @@ public class AuditTrailFilterTest {
         }
 
         String log = Util.loadFile(new File(tmpDir.getRoot(), "test.log.0"), StandardCharsets.UTF_8);
-        assertTrue("logged actions: " + log, Pattern.compile(".*id=1.*job/test-job.*by \\Q127.0.0.1\\E.*", Pattern.DOTALL).matcher(log).matches());
+        assertTrue("logged actions: " + log, Pattern.compile(".*id=1.*job/test-job.*by \\QNA from 127.0.0.1\\E.*", Pattern.DOTALL).matcher(log).matches());
     }
 
     @Test
@@ -98,7 +98,7 @@ public class AuditTrailFilterTest {
         j.submit(form);
 
         String log = Util.loadFile(new File(tmpDir.getRoot(), "create-item.log.0"), StandardCharsets.UTF_8);
-        assertTrue("logged actions: " + log, Pattern.compile(".*createItem \\(" + jobName + "\\).*by \\Q127.0.0.1\\E.*", Pattern.DOTALL).matcher(log).matches());
+        assertTrue("logged actions: " + log, Pattern.compile(".*createItem \\(" + jobName + "\\).*by \\QNA from 127.0.0.1\\E.*", Pattern.DOTALL).matcher(log).matches());
 
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] JENKINS-65868
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

In addition to username remote IP-address of a client is added to log entry of AuditTrail log.
![Log output example](https://user-images.githubusercontent.com/63276540/121671177-eaf95700-cab6-11eb-8b3e-0f284050c8c1.PNG)

Justification:
There are cases when a potential Jenkins attacker can get access to a service account.
In this case this attacker can't be identified.
Information about a remote client IP-address may simplify an investigation process in future.

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
