### PR TITLE
Remove deprecated `java.level` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/audit-trail-plugin</gitHubRepo>
         <jenkins.version>2.346.1</jenkins.version>
-        <java.level>8</java.level>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
 


### PR DESCRIPTION
The `java.level` property was deprecated in [plugin parent POM 4.40](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.40) and should be removed from this plugin's POM. In the future this warning will be changed to an error and will break the build. See https://github.com/jenkinsci/plugin-pom/pull/522 for details.