### PR TITLE
Shows display name of user instead of Id

### DIFF
--- a/src/main/java/hudson/plugins/audit_trail/AuditTrailFilter.java
+++ b/src/main/java/hudson/plugins/audit_trail/AuditTrailFilter.java
@@ -83,7 +83,7 @@ public class AuditTrailFilter implements Filter {
         String uri = getPathInfo(req);
         if (uriPattern != null && uriPattern.matcher(uri).matches()) {
             User user = User.current();
-            String username = user != null ? user.getDisplayName() : "NA";
+            String username = user != null ? (configuration.shouldDisplayUserName()? user.getDisplayName(): user.getId()) : "NA";
             String remoteIP = req.getRemoteAddr();
             String extra = "";
             // For queue items, show what task is in the queue:

--- a/src/main/java/hudson/plugins/audit_trail/AuditTrailFilter.java
+++ b/src/main/java/hudson/plugins/audit_trail/AuditTrailFilter.java
@@ -83,7 +83,7 @@ public class AuditTrailFilter implements Filter {
         String uri = getPathInfo(req);
         if (uriPattern != null && uriPattern.matcher(uri).matches()) {
             User user = User.current();
-            String username = user != null ? user.getId() : "NA";
+            String username = user != null ? user.getDisplayName() : "NA";
             String remoteIP = req.getRemoteAddr();
             String extra = "";
             // For queue items, show what task is in the queue:

--- a/src/main/java/hudson/plugins/audit_trail/AuditTrailFilter.java
+++ b/src/main/java/hudson/plugins/audit_trail/AuditTrailFilter.java
@@ -83,7 +83,9 @@ public class AuditTrailFilter implements Filter {
         String uri = getPathInfo(req);
         if (uriPattern != null && uriPattern.matcher(uri).matches()) {
             User user = User.current();
-            String username = user != null ? (configuration.shouldDisplayUserName()? user.getDisplayName(): user.getId()) : "NA";
+            String username = user != null
+                    ? (configuration.shouldDisplayUserName() ? user.getDisplayName() : user.getId())
+                    : "NA";
             String remoteIP = req.getRemoteAddr();
             String extra = "";
             // For queue items, show what task is in the queue:

--- a/src/main/java/hudson/plugins/audit_trail/AuditTrailPlugin.java
+++ b/src/main/java/hudson/plugins/audit_trail/AuditTrailPlugin.java
@@ -67,6 +67,7 @@ public class AuditTrailPlugin extends GlobalConfiguration {
 
     private static final Logger LOGGER = Logger.getLogger(AuditTrailPlugin.class.getName());
     private boolean logBuildCause = true;
+    private boolean displayUserName = false;
     private boolean logCredentialsUsage = true;
     private List<AuditLogger> loggers = new ArrayList<>();
 
@@ -118,6 +119,13 @@ public class AuditTrailPlugin extends GlobalConfiguration {
     public boolean shouldLogCredentialsUsage() {
         return logCredentialsUsage;
     }
+    public boolean shouldDisplayUserName() {
+        return displayUserName;
+    }
+    
+    public boolean getDisplayUserName() {
+        return shouldDisplayUserName();
+    }
 
     public List<AuditLogger> getLoggers() {
         return loggers;
@@ -166,6 +174,12 @@ public class AuditTrailPlugin extends GlobalConfiguration {
     @DataBoundSetter
     public void setLogCredentialsUsage(boolean logCredentialsUsage) {
         this.logCredentialsUsage = logCredentialsUsage;
+        save();
+    }
+
+    @DataBoundSetter
+    public void setDisplayUserName(boolean displayUserName) {
+        this.displayUserName = displayUserName;
         save();
     }
 

--- a/src/main/java/hudson/plugins/audit_trail/AuditTrailPlugin.java
+++ b/src/main/java/hudson/plugins/audit_trail/AuditTrailPlugin.java
@@ -119,10 +119,11 @@ public class AuditTrailPlugin extends GlobalConfiguration {
     public boolean shouldLogCredentialsUsage() {
         return logCredentialsUsage;
     }
+
     public boolean shouldDisplayUserName() {
         return displayUserName;
     }
-    
+
     public boolean getDisplayUserName() {
         return shouldDisplayUserName();
     }

--- a/src/main/resources/hudson/plugins/audit_trail/AuditTrailPlugin/config.jelly
+++ b/src/main/resources/hudson/plugins/audit_trail/AuditTrailPlugin/config.jelly
@@ -18,6 +18,9 @@
       <f:entry title="${%Log credentials usage}">
         <f:checkbox name="logCredentialsUsage" checked="${descriptor.logCredentialsUsage}"/>
       </f:entry>
+      <f:entry title="${%Display Username instead of UserID}">
+        <f:checkbox name="displayUserName" checked="${descriptor.displayUserName}"/>
+      </f:entry>
     </f:advanced>
   </f:section>
 </j:jelly>

--- a/src/test/java/hudson/plugins/audit_trail/SimpleAuditTrailPluginConfiguratorHelper.java
+++ b/src/test/java/hudson/plugins/audit_trail/SimpleAuditTrailPluginConfiguratorHelper.java
@@ -21,11 +21,13 @@ public class SimpleAuditTrailPluginConfiguratorHelper {
     private static final String LOG_CREDENTIALS_USAGE_INPUT_NAME = "logCredentialsUsage";
     private static final String ADD_LOGGER_BUTTON_TEXT = "Add Logger";
     private static final String LOG_FILE_COMBO_TEXT = new LogFileAuditLogger.DescriptorImpl().getDisplayName();
+    private static final String DISPLAY_USER_NAME_INPUT_NAME = "displayUserName";
 
     private final File logFile;
 
     private boolean logBuildCause = true;
     private boolean logCredentialsUsage = true;
+    private boolean displayUserName = false;
     private String pattern = ".*/(?:enable|cancelItem|quietDown|createItem)/?.*";
 
     public SimpleAuditTrailPluginConfiguratorHelper(File logFile) {
@@ -34,6 +36,11 @@ public class SimpleAuditTrailPluginConfiguratorHelper {
 
     public SimpleAuditTrailPluginConfiguratorHelper withLogBuildCause(boolean logBuildCause) {
         this.logBuildCause = logBuildCause;
+        return this;
+    }
+
+    public SimpleAuditTrailPluginConfiguratorHelper withDisplayUserName(boolean displayUserName) {
+        this.displayUserName = displayUserName;
         return this;
     }
 
@@ -60,6 +67,7 @@ public class SimpleAuditTrailPluginConfiguratorHelper {
         form.getInputByName(PATTERN_INPUT_NAME).setValue(pattern);
         form.getInputByName(LOG_BUILD_CAUSE_INPUT_NAME).setChecked(logBuildCause);
         form.getInputByName(LOG_CREDENTIALS_USAGE_INPUT_NAME).setChecked(logCredentialsUsage);
+        form.getInputByName(DISPLAY_USER_NAME_INPUT_NAME).setChecked(displayUserName);
         j.submit(form);
     }
 }

--- a/src/test/resources/hudson/plugins/audit_trail/expected.yml
+++ b/src/test/resources/hudson/plugins/audit_trail/expected.yml
@@ -1,3 +1,4 @@
+displayUserName: false
 logBuildCause: true
 logCredentialsUsage: true
 loggers:

--- a/src/test/resources/hudson/plugins/audit_trail/jcasc-console-and-file.yml
+++ b/src/test/resources/hudson/plugins/audit_trail/jcasc-console-and-file.yml
@@ -1,6 +1,7 @@
 unclassified:
   audit-trail:
     logBuildCause: true
+    displayUserName: false
     loggers:
       - console:
           dateFormat: "yyyy-MM-dd HH:mm:ss:SSS"

--- a/src/test/resources/hudson/plugins/audit_trail/jcasc.yml
+++ b/src/test/resources/hudson/plugins/audit_trail/jcasc.yml
@@ -1,6 +1,7 @@
 unclassified:
   audit-trail:
     logBuildCause: true
+    displayUserName: false
     loggers:
       - console:
           dateFormat: "yyyy-MM-dd HH:mm:ss:SSS"

--- a/src/test/resources/hudson/plugins/audit_trail/jenkins-12848.xml
+++ b/src/test/resources/hudson/plugins/audit_trail/jenkins-12848.xml
@@ -4,6 +4,7 @@
         .*/(?:configSubmit|doDelete|postBuildResult|enable|disable|cancelQueue|stop|toggleLogKeep|doWipeOutWorkspace|createItem|createView|toggleOffline|cancelQuietDown|quietDown|restart|exit|safeExit|cancelItem|updateSubmit)
     </pattern>
     <logBuildCause>true</logBuildCause>
+    <displayUserName>false</displayUserName>
     <loggers>
         <hudson.plugins.audit__trail.LogFileAuditLogger>
             <log>/tmp/xml-logs-12848</log>

--- a/src/test/resources/hudson/plugins/audit_trail/sample.xml
+++ b/src/test/resources/hudson/plugins/audit_trail/sample.xml
@@ -4,6 +4,7 @@
         .*/(?:configSubmit|doDelete|postBuildResult|enable|disable|cancelQueue|stop|toggleLogKeep|doWipeOutWorkspace|createItem|createView|toggleOffline|cancelQuietDown|quietDown|restart|exit|safeExit|cancelItem|updateSubmit)
     </pattern>
     <logBuildCause>true</logBuildCause>
+    <displayUserName>false</displayUserName>
     <loggers>
         <hudson.plugins.audit__trail.LogFileAuditLogger>
             <log>/tmp/xml-logs</log>


### PR DESCRIPTION
Shows display name of user instead of Id
Currently on the URL audit trail, instead of showing the Username, it only displays de ID, making it hard to debug or monitor. It only shows the username when a job is triggered.

![image](https://github.com/jenkinsci/audit-trail-plugin/assets/1645609/fbd0dab9-b80a-4a56-aae5-626c7033676c)

Now, with this small change, the username is shown, instead of the ID. In my case, I'm using Azure AD, which it was showing my User Object ID, really annoying to debug/monitor

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
```
