### PR TITLE
Fix: User.current() command doesn't work inside logRequest thread.

### DIFF
--- a/src/main/java/hudson/plugins/audit_trail/AuditLogger.java
+++ b/src/main/java/hudson/plugins/audit_trail/AuditLogger.java
@@ -15,7 +15,7 @@ public abstract class AuditLogger implements Describable<AuditLogger>, Extension
     public abstract void log(String event);
 
     public Descriptor<AuditLogger> getDescriptor() {
-        return Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     /**
@@ -33,6 +33,6 @@ public abstract class AuditLogger implements Describable<AuditLogger>, Extension
      * Returns all the registered {@link AuditLogger} descriptors.
      */
     public static DescriptorExtensionList<AuditLogger, Descriptor<AuditLogger>> all() {
-        return Jenkins.getInstance().getDescriptorList(AuditLogger.class);
+        return Jenkins.get().getDescriptorList(AuditLogger.class);
     }
 }

--- a/src/main/java/hudson/plugins/audit_trail/ElasticSearchAuditLogger.java
+++ b/src/main/java/hudson/plugins/audit_trail/ElasticSearchAuditLogger.java
@@ -185,10 +185,7 @@ public class ElasticSearchAuditLogger extends AuditLogger {
     private StandardUsernamePasswordCredentials getUsernamePasswordCredentials(String credentialsId) {
         return (StandardUsernamePasswordCredentials) CredentialsMatchers.firstOrNull(
                 CredentialsProvider.lookupCredentials(
-                        StandardUsernamePasswordCredentials.class,
-                        Jenkins.getInstance(),
-                        ACL.SYSTEM,
-                        Collections.emptyList()),
+                        StandardUsernamePasswordCredentials.class, Jenkins.get(), ACL.SYSTEM, Collections.emptyList()),
                 CredentialsMatchers.withId(credentialsId));
     }
 
@@ -200,10 +197,7 @@ public class ElasticSearchAuditLogger extends AuditLogger {
     private StandardCertificateCredentials getCertificateCredentials(String credentialsId) {
         return (StandardCertificateCredentials) CredentialsMatchers.firstOrNull(
                 CredentialsProvider.lookupCredentials(
-                        StandardCertificateCredentials.class,
-                        Jenkins.getInstance(),
-                        ACL.SYSTEM,
-                        Collections.emptyList()),
+                        StandardCertificateCredentials.class, Jenkins.get(), ACL.SYSTEM, Collections.emptyList()),
                 CredentialsMatchers.withId(credentialsId));
     }
 
@@ -426,7 +420,7 @@ public class ElasticSearchAuditLogger extends AuditLogger {
 
         public ListBoxModel doFillUsernamePasswordCredentialsIdItems(
                 @QueryParameter String usernamePasswordCredentialsId, @QueryParameter String url) {
-            if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
                 return new StandardListBoxModel().includeCurrentValue(usernamePasswordCredentialsId);
             }
             List<DomainRequirement> domainRequirements =
@@ -435,7 +429,7 @@ public class ElasticSearchAuditLogger extends AuditLogger {
                     .includeEmptyValue()
                     .includeMatchingAs(
                             ACL.SYSTEM,
-                            Jenkins.getInstance(),
+                            Jenkins.get(),
                             StandardCredentials.class,
                             domainRequirements,
                             CredentialsMatchers.anyOf(
@@ -445,7 +439,7 @@ public class ElasticSearchAuditLogger extends AuditLogger {
 
         public ListBoxModel doFillClientCertificateCredentialsIdItems(
                 @QueryParameter String clientCertificateCredentialsId, @QueryParameter String url) {
-            if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
                 return new StandardListBoxModel().includeCurrentValue(clientCertificateCredentialsId);
             }
             List<DomainRequirement> domainRequirements =
@@ -454,7 +448,7 @@ public class ElasticSearchAuditLogger extends AuditLogger {
                     .includeEmptyValue()
                     .includeMatchingAs(
                             ACL.SYSTEM,
-                            Jenkins.getInstance(),
+                            Jenkins.get(),
                             StandardCertificateCredentials.class,
                             domainRequirements,
                             CredentialsMatchers.anyOf(


### PR DESCRIPTION
AuditTrailFilter.java:
- Looks like **User.current()** command doesn't work inside a thread, because it always return null, so I'm passing the object from outside the thread (**doFilter**).
- This bug was introduced here: https://github.com/jenkinsci/audit-trail-plugin/pull/125

Before
![image](https://github.com/jenkinsci/audit-trail-plugin/assets/1645609/c5fa2021-3df3-4ba9-9f1f-009942f54df3)
After
![image](https://github.com/jenkinsci/audit-trail-plugin/assets/1645609/1ce6fc92-87c8-4e77-b1a2-8f1d81dc6edc)



- Changed **Jenkins.getInstace()** for **Jenkins.get()**. https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#getInstance()

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```