### PR TITLE
[chore] Remove explicit checkurl

### DIFF
--- a/src/main/java/hudson/plugins/audit_trail/AuditTrailPlugin.java
+++ b/src/main/java/hudson/plugins/audit_trail/AuditTrailPlugin.java
@@ -242,7 +242,7 @@ public class AuditTrailPlugin extends GlobalConfiguration {
     /**
      * Validate regular expression syntax.
      */
-    public FormValidation doRegexCheck(@QueryParameter final String value) throws IOException, ServletException {
+    public FormValidation doCheckPattern(@QueryParameter final String value) throws IOException, ServletException {
         // No permission needed for simple syntax check
         try {
             Pattern.compile(value);

--- a/src/main/resources/hudson/plugins/audit_trail/AuditTrailPlugin/config.jelly
+++ b/src/main/resources/hudson/plugins/audit_trail/AuditTrailPlugin/config.jelly
@@ -8,18 +8,17 @@
             addCaption="${%Add Logger}"/>
     </f:entry>
     <f:advanced>
-      <f:entry title="${%URL Patterns to Log}">
-        <f:textbox name="pattern" value="${descriptor.pattern}"
-         checkUrl="'descriptorByName/AuditTrailPlugin/regexCheck?value='+encode(this.value)"/>
+      <f:entry field="pattern" title="${%URL Patterns to Log}">
+        <f:textbox value="${descriptor.pattern}"/>
       </f:entry>
-      <f:entry title="${%Log how each build is triggered}">
-        <f:checkbox name="logBuildCause" checked="${descriptor.logBuildCause}"/>
+      <f:entry field="logBuildCause" title="${%Log how each build is triggered}">
+        <f:checkbox checked="${descriptor.logBuildCause}"/>
       </f:entry>
-      <f:entry title="${%Log credentials usage}">
-        <f:checkbox name="logCredentialsUsage" checked="${descriptor.logCredentialsUsage}"/>
+      <f:entry field="logCredentialsUsage" title="${%Log credentials usage}">
+        <f:checkbox checked="${descriptor.logCredentialsUsage}"/>
       </f:entry>
-      <f:entry title="${%Display Username instead of UserID}">
-        <f:checkbox name="displayUserName" checked="${descriptor.displayUserName}"/>
+      <f:entry field="displayUserName" title="${%Display Username instead of UserID}">
+        <f:checkbox checked="${descriptor.displayUserName}"/>
       </f:entry>
     </f:advanced>
   </f:section>

--- a/src/test/java/hudson/plugins/audit_trail/SimpleAuditTrailPluginConfiguratorHelper.java
+++ b/src/test/java/hudson/plugins/audit_trail/SimpleAuditTrailPluginConfiguratorHelper.java
@@ -16,12 +16,12 @@ public class SimpleAuditTrailPluginConfiguratorHelper {
     private static final String LOG_FILE_SIZE_INPUT_NAME = "_.limit";
     private static final String LOG_FILE_COUNT_INPUT_NAME = "_.count";
     private static final String LOG_FILE_LOG_SEPARATOR_INPUT_NAME = "_.logSeparator";
-    private static final String PATTERN_INPUT_NAME = "pattern";
-    private static final String LOG_BUILD_CAUSE_INPUT_NAME = "logBuildCause";
-    private static final String LOG_CREDENTIALS_USAGE_INPUT_NAME = "logCredentialsUsage";
+    private static final String PATTERN_INPUT_NAME = "_.pattern";
+    private static final String LOG_BUILD_CAUSE_INPUT_NAME = "_.logBuildCause";
+    private static final String LOG_CREDENTIALS_USAGE_INPUT_NAME = "_.logCredentialsUsage";
     private static final String ADD_LOGGER_BUTTON_TEXT = "Add Logger";
     private static final String LOG_FILE_COMBO_TEXT = new LogFileAuditLogger.DescriptorImpl().getDisplayName();
-    private static final String DISPLAY_USER_NAME_INPUT_NAME = "displayUserName";
+    private static final String DISPLAY_USER_NAME_INPUT_NAME = "_.displayUserName";
 
     private final File logFile;
 


### PR DESCRIPTION
by using field instead of name on the pattern and renaming the method the explicit checkurl is no longer needed
Having the field on the entry also has the sideffec that the help for the pattern is now available

The old checkurl was using inline javascript which is not CSP compliant

<!-- Please describe your pull request here. -->

### Testing done
Manual testing that values are still properly save. Entering an invalid pattern still triggers error message below

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
