### PR TITLE
use jenkins-button for the monitor

### DIFF
--- a/src/main/resources/hudson/plugins/audit_trail/BypassablePatternMonitor/message.groovy
+++ b/src/main/resources/hudson/plugins/audit_trail/BypassablePatternMonitor/message.groovy
@@ -10,10 +10,14 @@ def docLink = 'https://github.com/jenkinsci/audit-trail-plugin/tree/master/docs/
 dl {
     div(class: 'alert alert-warning') {
         form(method: 'post', name: 'default', action: "${rootURL}/${monitor.url}/applyDefault") {
-            input(name: 'default', type: 'submit', value: 'Apply default pattern', class: 'submit-button primary')
+            button(name: 'default', type: 'submit', class: 'jenkins-button jenkins-button--primary') {
+                text("Apply default pattern")
+            }
         }
         form(method: 'get', name: 'redirect-to-config', action: "${rootURL}/${monitor.url}/redirectToConfig") {
-            input(name: 'config', type: 'submit', value: 'Go to configuration', class: 'submit-button primary')
+            button(name: 'config', type: 'submit', class: 'jenkins-button jenkins-button--primary jenkins-!-margin-right-1') {
+                text("Go to configuration")
+            }
         }
         raw('<b>Found bypassable Audit Trail logging patterns:</b>')
         raw(monitor.message)


### PR DESCRIPTION
replace `<input type="submit"` with `<button type="submit"` and proper classes so the buttons are styled in the proper way and no legacy yui stuff is used.
Add some margin between the buttons


Before:
![image](https://github.com/user-attachments/assets/5daba5f9-07ad-40fd-82d5-1a6e2e0e28b0)

After:
![image](https://github.com/user-attachments/assets/2dfefbbc-2f96-4a1c-9513-680ca7d0bccf)

<!-- Please describe your pull request here. -->

### Testing done
Manual testing

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
