### PR TITLE
Avoid looking up configuration if the filter is called too early in the init sequence

### DIFF
--- a/src/main/java/hudson/plugins/audit_trail/AuditTrailFilter.java
+++ b/src/main/java/hudson/plugins/audit_trail/AuditTrailFilter.java
@@ -122,7 +122,8 @@ public class AuditTrailFilter implements Filter {
     }
 
     private boolean isShouldDisplayUserName() {
-        return getConfiguration() != null && getConfiguration().shouldDisplayUserName();
+        var configuration = getConfiguration();
+        return configuration != null && configuration.shouldDisplayUserName();
     }
 
     @CheckForNull

--- a/src/main/java/hudson/plugins/audit_trail/AuditTrailFilter.java
+++ b/src/main/java/hudson/plugins/audit_trail/AuditTrailFilter.java
@@ -69,8 +69,7 @@ public class AuditTrailFilter implements Filter {
      * @deprecated as of 2.6
      **/
     @Deprecated
-    public AuditTrailFilter(AuditTrailPlugin plugin) {
-    }
+    public AuditTrailFilter(AuditTrailPlugin plugin) {}
 
     public AuditTrailFilter() {
         // used by the injector
@@ -111,10 +110,7 @@ public class AuditTrailFilter implements Filter {
                 extra = formatExtraInfoString(request.getParameter("name"));
             }
 
-
-            String username = user != null
-                    ? (isShouldDisplayUserName() ? user.getDisplayName() : user.getId())
-                    : "NA";
+            String username = user != null ? (isShouldDisplayUserName() ? user.getDisplayName() : user.getId()) : "NA";
             if (LOGGER.isLoggable(Level.FINE))
                 LOGGER.log(
                         Level.FINE, "Audit request {0} by user {1} from {2}", new Object[] {uri, username, remoteIP});


### PR DESCRIPTION
I've seen a deadlock on Jenkins startup due to this.

```
"GitSCM.onLoaded":
  waiting for ownable synchronizer 0x00000006d8464c68, (a java.util.concurrent.locks.ReentrantLock$NonfairSync),
  which is held by "AuditTrailFilter.init"

"AuditTrailFilter.init":
  waiting to lock monitor 0x00007ed65056d880 (object 0x00000006d1000000, a hudson.ExtensionList$Lock),
  which is held by "GitSCM.onLoaded"
```

This change prevents loading configuration from the filter unless Jenkins startup has progress to a state where all extensions are available.

Also moves to `HttpServletFilter` extension point which simplifies filter registration.

cc @PierreBtz 

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
