### PR TITLE
Update `syslog-java-client` from 1.1.7 to 1.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,9 +63,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.cloudbees</groupId>
+      <groupId>io.jenkins.lib</groupId>
       <artifactId>syslog-java-client</artifactId>
-      <version>1.1.7</version>
+      <version>1.1.8</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
The latest release is now published on Maven Central and has a new group ID.