### PR TITLE
[JENKINS-75458] Prevent credential problems from flushing Audit Trail settings when logging to Elastic

### DIFF
--- a/src/main/java/hudson/plugins/audit_trail/ElasticSearchAuditLogger.java
+++ b/src/main/java/hudson/plugins/audit_trail/ElasticSearchAuditLogger.java
@@ -141,11 +141,15 @@ public class ElasticSearchAuditLogger extends AuditLogger {
         String password = null;
         if (!StringUtils.isBlank(usernamePasswordCredentialsId)) {
             LOGGER.fine("Username/password credentials specified: " + usernamePasswordCredentialsId);
-            StandardUsernamePasswordCredentials usernamePasswordCredentials =
-                    getUsernamePasswordCredentials(usernamePasswordCredentialsId);
-            if (usernamePasswordCredentials != null) {
-                username = usernamePasswordCredentials.getUsername();
-                password = Secret.toString(usernamePasswordCredentials.getPassword());
+            try {
+                StandardUsernamePasswordCredentials usernamePasswordCredentials =
+                        getUsernamePasswordCredentials(usernamePasswordCredentialsId);
+                if (usernamePasswordCredentials != null) {
+                    username = usernamePasswordCredentials.getUsername();
+                    password = Secret.toString(usernamePasswordCredentials.getPassword());
+                }
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE, "Unable to resolve credentials for ElasticSearchSender", e);
             }
         }
         KeyStore clientKeyStore = null;


### PR DESCRIPTION
Add a try/catch around the retrieval of username and password for the Elastic connection to handle cases when there are problems resolving that data. E.g. in the case of secrets/credentials being managed in a third party system such as Vault, and the not being available for some reason (system outage, config error, network problems, etc).

### Testing done

Created a private build of the change and deployed it to a Vault - Jenkins - Elastic setup and added a system logger for `hudson.plugins.audit_trail.ElasticSearchAuditLogger` to observe more details.
* Verified that data is logged in the normal case
* Changed the Vault hostname to something incorrect and restarted Jenkins
* Verified that the config was not treated as unreadable
* Verified that configured Elast Logger values in system settings were shown
* Corrected Vault hostname
* Observed that the Audit Trail plugin preserved it's settings, recovered and started logging
* Repeated the procedure above with incorrect port in the Vault setting and incorrect Vault credentials
* Also tested removing the credential id in the Jenkins credential store. No regression compared to current release ion this case.  (But this is handled somewhere else than `ElasticSearchAuditLogger`, so it does not show up in the log below)
 
See log data for details:
[CapturedLoginfo.txt](https://github.com/user-attachments/files/21936379/CapturedLoginfo.txt)

Perhaps a general "catch all exception types" is not a good solution, but as can be seen in the log excerpt, several different exceptions can occur.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

