### PR TITLE
JENKINS-76476 Add controller and plugin information to documents logged to Elastic Search

### DIFF
--- a/src/main/java/hudson/plugins/audit_trail/ElasticSearchAuditLogger.java
+++ b/src/main/java/hudson/plugins/audit_trail/ElasticSearchAuditLogger.java
@@ -391,13 +391,23 @@ public class ElasticSearchAuditLogger extends AuditLogger {
                     "@timestamp", DATE_FORMATTER.format(Calendar.getInstance().getTime()));
             payload.put("jenkins.version", Jenkins.VERSION);
             payload.put("jenkins.url", Jenkins.get().getRootUrl());
-            payload.put("jenkins.audittrail.plugin.version", Jenkins.get().pluginManager.getPlugin("audit-trail").getVersion().toString());
+            payload.put(
+                "jenkins.audittrail.plugin.version",
+                Jenkins.get()
+                    .pluginManager
+                    .getPlugin("audit-trail")
+                    .getVersion()
+                    .toString());
             try {
-                    payload.put("jenkins.controller.computer.name", java.net.InetAddress.getLocalHost().getHostName());
-                    payload.put("jenkins.controller.computer.address", java.net.InetAddress.getLocalHost().getHostAddress());
+                    payload.put(
+                        "jenkins.controller.computer.name",
+                        java.net.InetAddress.getLocalHost().getHostName());
+                    payload.put(
+                        "jenkins.controller.computer.address",
+                        java.net.InetAddress.getLocalHost().getHostAddress());
             } catch (Exception e) {
-                    payload.put("jenkins.controller.computer.name", "");
-                    payload.put("jenkins.controller.computer.address", "");
+                payload.put("jenkins.controller.computer.name", "");
+                payload.put("jenkins.controller.computer.address", "");
             }
             StringEntity input = new StringEntity(
                     payload.toString(), ContentType.APPLICATION_JSON, StandardCharsets.UTF_8.name(), false);

--- a/src/main/java/hudson/plugins/audit_trail/ElasticSearchAuditLogger.java
+++ b/src/main/java/hudson/plugins/audit_trail/ElasticSearchAuditLogger.java
@@ -389,6 +389,16 @@ public class ElasticSearchAuditLogger extends AuditLogger {
             payload.put("message", data);
             payload.put(
                     "@timestamp", DATE_FORMATTER.format(Calendar.getInstance().getTime()));
+            payload.put("jenkins.version", Jenkins.VERSION);
+            payload.put("jenkins.url", Jenkins.get().getRootUrl());
+            payload.put("jenkins.audittrail.plugin.version", Jenkins.get().pluginManager.getPlugin("audit-trail").getVersion().toString());
+            try {
+                    payload.put("jenkins.controller.computer.name", java.net.InetAddress.getLocalHost().getHostName());
+                    payload.put("jenkins.controller.computer.address", java.net.InetAddress.getLocalHost().getHostAddress());
+            } catch (Exception e) {
+                    payload.put("jenkins.controller.computer.name", "");
+                    payload.put("jenkins.controller.computer.address", "");
+            }
             StringEntity input = new StringEntity(
                     payload.toString(), ContentType.APPLICATION_JSON, StandardCharsets.UTF_8.name(), false);
             postRequest.setEntity(input);

--- a/src/main/java/hudson/plugins/audit_trail/ElasticSearchAuditLogger.java
+++ b/src/main/java/hudson/plugins/audit_trail/ElasticSearchAuditLogger.java
@@ -331,6 +331,8 @@ public class ElasticSearchAuditLogger extends AuditLogger {
             }
             this.skipCertificateValidation = skipCertificateValidation;
             httpClient = createHttpClient(clientKeyStore, clientKeyStorePassword, skipCertificateValidation);
+
+            // Cache hostname and address to prevent potential delays caused by DNS queries
             String hostName;
             try {
                 hostName = java.net.InetAddress.getLocalHost().getHostName();

--- a/src/main/java/hudson/plugins/audit_trail/ElasticSearchAuditLogger.java
+++ b/src/main/java/hudson/plugins/audit_trail/ElasticSearchAuditLogger.java
@@ -392,7 +392,7 @@ public class ElasticSearchAuditLogger extends AuditLogger {
                     "@timestamp", DATE_FORMATTER.format(Calendar.getInstance().getTime()));
             payload.put("jenkins.version", Jenkins.VERSION);
             payload.put("jenkins.url", Jenkins.get().getRootUrl());
-            PluginWrapper plugin = Jenkins.get().pluginManager.getPlugin("audit-trail");
+            PluginWrapper plugin = Jenkins.get().getPluginManager().getPlugin("audit-trail");
             if (plugin != null) {
                 payload.put("jenkins.audittrail.plugin.version", plugin.getVersion());
             } else {

--- a/src/main/java/hudson/plugins/audit_trail/ElasticSearchAuditLogger.java
+++ b/src/main/java/hudson/plugins/audit_trail/ElasticSearchAuditLogger.java
@@ -311,6 +311,8 @@ public class ElasticSearchAuditLogger extends AuditLogger {
         private final String url;
         private final String auth;
         private final boolean skipCertificateValidation;
+        private final String localHostName;
+        private final String localHostAddress;
 
         public ElasticSearchSender(
                 String url,
@@ -329,6 +331,20 @@ public class ElasticSearchAuditLogger extends AuditLogger {
             }
             this.skipCertificateValidation = skipCertificateValidation;
             httpClient = createHttpClient(clientKeyStore, clientKeyStorePassword, skipCertificateValidation);
+            String hostName;
+            try {
+                hostName = java.net.InetAddress.getLocalHost().getHostName();
+            } catch (Exception e) {
+                hostName = "";
+            }
+            this.localHostName = hostName;
+            String hostAddress;
+            try {
+                hostAddress = java.net.InetAddress.getLocalHost().getHostAddress();
+            } catch (Exception e) {
+                hostAddress = "";
+            }
+            this.localHostAddress = hostAddress;
         }
 
         public String getUrl() {
@@ -398,17 +414,8 @@ public class ElasticSearchAuditLogger extends AuditLogger {
             } else {
                 payload.put("jenkins.audittrail.plugin.version", "");
             }
-            try {
-                payload.put(
-                        "jenkins.controller.computer.name",
-                        java.net.InetAddress.getLocalHost().getHostName());
-                payload.put(
-                        "jenkins.controller.computer.address",
-                        java.net.InetAddress.getLocalHost().getHostAddress());
-            } catch (Exception e) {
-                payload.put("jenkins.controller.computer.name", "");
-                payload.put("jenkins.controller.computer.address", "");
-            }
+            payload.put("jenkins.controller.computer.name", localHostName);
+            payload.put("jenkins.controller.computer.address", localHostAddress);
             StringEntity input = new StringEntity(
                     payload.toString(), ContentType.APPLICATION_JSON, StandardCharsets.UTF_8.name(), false);
             postRequest.setEntity(input);

--- a/src/main/java/hudson/plugins/audit_trail/ElasticSearchAuditLogger.java
+++ b/src/main/java/hudson/plugins/audit_trail/ElasticSearchAuditLogger.java
@@ -33,6 +33,7 @@ import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredenti
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import hudson.Extension;
+import hudson.PluginWrapper;
 import hudson.model.Descriptor;
 import hudson.security.ACL;
 import hudson.util.FormValidation;
@@ -391,18 +392,17 @@ public class ElasticSearchAuditLogger extends AuditLogger {
                     "@timestamp", DATE_FORMATTER.format(Calendar.getInstance().getTime()));
             payload.put("jenkins.version", Jenkins.VERSION);
             payload.put("jenkins.url", Jenkins.get().getRootUrl());
-            payload.put(
-                "jenkins.audittrail.plugin.version",
-                Jenkins.get()
-                    .pluginManager
-                    .getPlugin("audit-trail")
-                    .getVersion()
-                    .toString());
+            PluginWrapper plugin = Jenkins.get().pluginManager.getPlugin("audit-trail");
+            if (plugin != null) {
+                payload.put("jenkins.audittrail.plugin.version", plugin.getVersion());
+            } else {
+                payload.put("jenkins.audittrail.plugin.version", "");
+            }
             try {
-                    payload.put(
+                payload.put(
                         "jenkins.controller.computer.name",
                         java.net.InetAddress.getLocalHost().getHostName());
-                    payload.put(
+                payload.put(
                         "jenkins.controller.computer.address",
                         java.net.InetAddress.getLocalHost().getHostAddress());
             } catch (Exception e) {

--- a/src/test/java/hudson/plugins/audit_trail/ElasticSearchAuditLoggerTest.java
+++ b/src/test/java/hudson/plugins/audit_trail/ElasticSearchAuditLoggerTest.java
@@ -56,18 +56,22 @@ public class ElasticSearchAuditLoggerTest {
     public void testGetHttpPostContainsExpectedKeys() throws Exception {
         ElasticSearchAuditLogger auditLogger = new ElasticSearchAuditLogger(esUrl, true);
         auditLogger.configure();
-
+        assertTrue(auditLogger.getElasticSearchSender() != null);
         HttpPost post = auditLogger.getElasticSearchSender().getHttpPost("test-event");
-
         String body = EntityUtils.toString(post.getEntity());
         JSONObject json = JSONObject.fromObject(body);
-
         assertTrue("message key should be present", json.containsKey("message"));
         assertTrue("@timestamp key should be present", json.containsKey("@timestamp"));
         assertTrue("jenkins.version key should be present", json.containsKey("jenkins.version"));
         assertTrue("jenkins.url key should be present", json.containsKey("jenkins.url"));
-        assertTrue("jenkins.audittrail.plugin.version key should be present", json.containsKey("jenkins.audittrail.plugin.version"));
-        assertTrue("jenkins.controller.computer.name key should be present", json.containsKey("jenkins.controller.computer.name"));
-        assertTrue("jenkins.controller.computer.address key should be present", json.containsKey("jenkins.controller.computer.address"));
+        assertTrue(
+            "jenkins.audittrail.plugin.version key should be present",
+            json.containsKey("jenkins.audittrail.plugin.version"));
+        assertTrue(
+            "jenkins.controller.computer.name key should be present",
+            json.containsKey("jenkins.controller.computer.name"));
+        assertTrue(
+            "jenkins.controller.computer.address key should be present",
+            json.containsKey("jenkins.controller.computer.address"));
     }
 }

--- a/src/test/java/hudson/plugins/audit_trail/ElasticSearchAuditLoggerTest.java
+++ b/src/test/java/hudson/plugins/audit_trail/ElasticSearchAuditLoggerTest.java
@@ -65,13 +65,13 @@ public class ElasticSearchAuditLoggerTest {
         assertTrue("jenkins.version key should be present", json.containsKey("jenkins.version"));
         assertTrue("jenkins.url key should be present", json.containsKey("jenkins.url"));
         assertTrue(
-            "jenkins.audittrail.plugin.version key should be present",
-            json.containsKey("jenkins.audittrail.plugin.version"));
+                "jenkins.audittrail.plugin.version key should be present",
+                json.containsKey("jenkins.audittrail.plugin.version"));
         assertTrue(
-            "jenkins.controller.computer.name key should be present",
-            json.containsKey("jenkins.controller.computer.name"));
+                "jenkins.controller.computer.name key should be present",
+                json.containsKey("jenkins.controller.computer.name"));
         assertTrue(
-            "jenkins.controller.computer.address key should be present",
-            json.containsKey("jenkins.controller.computer.address"));
+                "jenkins.controller.computer.address key should be present",
+                json.containsKey("jenkins.controller.computer.address"));
     }
 }

--- a/src/test/java/hudson/plugins/audit_trail/ElasticSearchAuditLoggerTest.java
+++ b/src/test/java/hudson/plugins/audit_trail/ElasticSearchAuditLoggerTest.java
@@ -4,6 +4,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import jenkins.model.GlobalConfiguration;
+import net.sf.json.JSONObject;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlPage;
 import org.junit.Rule;
@@ -47,5 +50,24 @@ public class ElasticSearchAuditLoggerTest {
         assertTrue(auditLogger.getElasticSearchSender() != null);
         assertEquals(esUrl, auditLogger.getElasticSearchSender().getUrl());
         assertEquals(true, auditLogger.getElasticSearchSender().getSkipCertificateValidation());
+    }
+
+    @Test
+    public void testGetHttpPostContainsExpectedKeys() throws Exception {
+        ElasticSearchAuditLogger auditLogger = new ElasticSearchAuditLogger(esUrl, true);
+        auditLogger.configure();
+
+        HttpPost post = auditLogger.getElasticSearchSender().getHttpPost("test-event");
+
+        String body = EntityUtils.toString(post.getEntity());
+        JSONObject json = JSONObject.fromObject(body);
+
+        assertTrue("message key should be present", json.containsKey("message"));
+        assertTrue("@timestamp key should be present", json.containsKey("@timestamp"));
+        assertTrue("jenkins.version key should be present", json.containsKey("jenkins.version"));
+        assertTrue("jenkins.url key should be present", json.containsKey("jenkins.url"));
+        assertTrue("jenkins.audittrail.plugin.version key should be present", json.containsKey("jenkins.audittrail.plugin.version"));
+        assertTrue("jenkins.controller.computer.name key should be present", json.containsKey("jenkins.controller.computer.name"));
+        assertTrue("jenkins.controller.computer.address key should be present", json.containsKey("jenkins.controller.computer.address"));
     }
 }


### PR DESCRIPTION
This Pull Request adds information to documents logged to Elastic Search to make it possible to distinguish different Jenkins Controllers from each other when logging to the same index in Elastic Search. (Inspired by the keys/fields sent by the OTEL plugin)

See https://issues.jenkins.io/browse/JENKINS-76476 also.

### Testing done

The changes have been built locally and deployed to a live Jenkins setup logging to an Elastic Search backend. Existence of the added keys/information have been verified in Elastic.

```
...
  "_source": {
    "message": "/job/zLAB/job/HelloDemo/configSubmit by njesper from X.Y.Z.Q",
    "@timestamp": "2026-06-09T09:42:11+0000",
    "jenkins.version": "2.555.2",
    "jenkins.url": "https://jcasc-internal.com/audlog/",
    "jenkins.audittrail.plugin.version": "999999-SNAPSHOT (private-06/09/2026 09:27-root)",
    "jenkins.controller.computer.name": "8bc564d4c626",
    "jenkins.controller.computer.address": "A.B.C.D"
  },
 ...
```

Automated tests have been added to the project, checking that expected keys exists in the log documents being prepared to be sent to Elastic.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
